### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/src/reverse_decoding.py
+++ b/src/reverse_decoding.py
@@ -71,7 +71,7 @@ for iter in range(1000):
     _right_context_probs = nn.CrossEntropyLoss()(probs_so_far.view(-1, probs_so_far.size(-1)),
                                                  right_context_ids.view(-1).repeat(batch_size))
 
-    # TODO: instead of maximizing entropy, maximize the maximum of the probabilty distribution
+    # TODO: instead of maximizing entropy, maximize the maximum of the probability distribution
     # minimize entropy so that we get peaky distributions
     _entropy = -torch.mean(
         # entropy for each position

--- a/src/scale_invariance.py
+++ b/src/scale_invariance.py
@@ -114,7 +114,7 @@ class EmbeddingProjection(torch.nn.Module):
 
     def forward(self, x, gold_projected):
         projected = self.linear(x)
-        # TOOD: add a condition for loss computation
+        # TODO: add a condition for loss computation
         # alternatively: nn.L1Loss
         # loss = torch.nn.MSELoss()(projected, gold_projected)
         loss = torch.nn.L1Loss()(projected, gold_projected)
@@ -230,7 +230,7 @@ class EmbeddingProjection1(torch.nn.Module):
 
     # norm(e1 - L x E1) + norm(e2 - L x E2)
     def forward(self, prompt1, model1embedding, model2embedding):
-        # TOOD: add a condition for loss computation
+        # TODO: add a condition for loss computation
         # alternatively: nn.L1Loss
         # loss = torch.nn.MSELoss()(projected, gold_projected)
         norm = torch.nn.MSELoss()


### PR DESCRIPTION
$ `codespell`
```
./src/scale_invariance.py:117: TOOD ==> TODO
./src/scale_invariance.py:233: TOOD ==> TODO
./src/reverse_decoding.py:74: probabilty ==> probability
```